### PR TITLE
Page title weg

### DIFF
--- a/templates/suspenders_layout.html.erb.erb
+++ b/templates/suspenders_layout.html.erb.erb
@@ -4,7 +4,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="robots" content="noopd" />
-  <title><%%= page_title %></title>
+  <title></title>
   <%%= stylesheet_link_tag :application, :media => 'all' %>
   <%%= javascript_include_tag :application %>
   <%%= csrf_meta_tags %>


### PR DESCRIPTION
Verwijder page title in layout omdat `flutie` niet meer gebruikt wordt.
