### PR TITLE
Remove initial commit creation

### DIFF
--- a/lib/bretels/app_builder.rb
+++ b/lib/bretels/app_builder.rb
@@ -179,8 +179,6 @@ module Bretels
 
     def init_git
       run 'git init'
-      run 'git add .'
-      run 'git commit -m "Initial commit" > /dev/null'
     end
 
     def create_heroku_apps


### PR DESCRIPTION
Somehow, after the initial commit, extra file changes are being generated.
This leaves the repository in a confusing state after running `bretels`.

Apart from this, I don't think it should be bretels' responsibility to do the
initial commit for us. Feels better to leave this to the user running bretels.
Configuring sane defaults for .gitignore and doing `git init` is fine.